### PR TITLE
Delete unused code

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -97,13 +97,6 @@ func (db *DB) Delete(t *Todo) error {
 	return db.todo.Delete("pk", t.Username).Range("sk", t.CreatedAt).Run()
 }
 
-// Check ...
-func (db *DB) Check(t *Todo) error {
-	return db.todo.Update("pk", t.Username).Range("sk", t.CreatedAt).
-		Set("CheckedAt", time.Now()).
-		Run()
-}
-
 // Find ...
 func (db *DB) Find(username string) ([]Todo, error) {
 	var todos []Todo


### PR DESCRIPTION
Delete unused code.
Running `staticcheck` produces the following results.

```bash
$ staticcheck -unused.whole-program ./...
internal/db/db.go:42:20: session.New is deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when t
he func is called instead of waiting to receive an error until a request is made.  (SA1019)
internal/db/db.go:96:15: func (*DB).Check is unused (U1001)
```

See also
  - https://staticcheck.io/docs