### PR TITLE
Fix pk to return valid string

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"crypto/sha1"
+	"encoding/hex"
 	"log"
 	"strings"
 	"time"
@@ -26,7 +27,7 @@ type User struct {
 func pk(username string) string {
 	h := sha1.New()
 	h.Write([]byte(username))
-	return string(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // Todo ...


### PR DESCRIPTION
Fix pk function to return valid string of hash.

```go
h := sha1.New()
h.Write([]byte("username"))

log.Println(string(h.Sum(nil))) // $��`���I��Z���4�
log.Println(hex.EncodeToString(h.Sum(nil))) // 249ba36000029bbe97499c03db5a9001f6b734ec
```